### PR TITLE
fix: too much padding between rhb-bands

### DIFF
--- a/public/assets/stylesheets/base.css
+++ b/public/assets/stylesheets/base.css
@@ -95,3 +95,7 @@ h6 {
 .danger {
   color: #a30000; /* WARNING: non-token value */
 }
+
+rhb-band + rhb-band {
+  padding-block-start: 0px !important;
+}


### PR DESCRIPTION
## What I did

- Added css rule for `rhb-band` siblings to reduce padding between them

Closes #53 