### PR TITLE
fix: missing icons

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -22,7 +22,10 @@ export default {
     }),
     copy({ targets: 
       [
-        { src: 'node_modules/@patternfly/icons/**/*', dest: './_site/assets/javascript/icons' }
+        { src: 'node_modules/@patternfly/icons/fas/*', dest: './_site/assets/javascript/icons/fas' },
+        { src: 'node_modules/@patternfly/icons/far/*', dest: './_site/assets/javascript/icons/far' },
+        { src: 'node_modules/@patternfly/icons/fab/*', dest: './_site/assets/javascript/icons/fab' },
+        { src: 'node_modules/@patternfly/icons/patternfly/*', dest: './_site/assets/javascript/icons/patternfly' }
       ]
     }),
   ],

--- a/website/_includes/components/rhb-recommend.webc
+++ b/website/_includes/components/rhb-recommend.webc
@@ -6,12 +6,12 @@
         <script webc:type="js">
           if(webc.attributes.hasOwnProperty('no')) {
             `<div class="flex-center danger">
-              <pf-icon icon="circle-xmark" size="md"></pf-icon> 
+              <pf-icon icon="times-circle" size="md"></pf-icon> 
               <span class="font-xl">Not this</span>
             </div>`
           } else {
             `<div class="flex-center success">
-              <pf-icon icon="circle-check" size="md"></pf-icon> 
+              <pf-icon icon="check-circle" size="md"></pf-icon> 
               <span class="font-xl">This</span>
             </div>`
           }


### PR DESCRIPTION
## What I did

- Fixed missing icons replacing with version 5 appropriate name

## Testing instructions

- View deploy preview on any page which uses `rhb-recommend` component

## Reviewer notes

When we bundled our dependencies instead of pulling from the CDN I also upgraded the version of RHDS and Patternfly at the same time.  In doing so brought in the Patternfly fix to the icons which aligned the icons to PFv4 which used font-awesome v5 instead of v6 as initially included.  This version change also contained different icon names for the check mark and xmark/times circled icons.  However the appearance of the icons should be the same.